### PR TITLE
Change CryptoException constructor visibility

### DIFF
--- a/src/main/java/de/petendi/commons/crypto/connector/CryptoException.java
+++ b/src/main/java/de/petendi/commons/crypto/connector/CryptoException.java
@@ -16,7 +16,7 @@
 package de.petendi.commons.crypto.connector;
 
 public class CryptoException extends Exception {
-    CryptoException(Exception e) {
+    public CryptoException(Exception e) {
         super(e);
     }
 


### PR DESCRIPTION
To implement connectors, which are located in different packages the constructor of the exception needs to be public
