### PR TITLE
Reimplemented HybridCrypto without key derivation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>de.petendi</groupId>
     <artifactId>commons-crypto</artifactId>
-    <version>1.1.0</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>commons-crypto</name>
     <description>A slim facade for common crypto operations </description>


### PR DESCRIPTION
We don't need to use a key derivation function when doing hybrid
encryption, because the SecretKey and IV can be directly encrypted.
